### PR TITLE
Update artemis cr to set persistenceEnabled to false

### DIFF
--- a/amq-broker-leader-follower-sharedmount.adoc
+++ b/amq-broker-leader-follower-sharedmount.adoc
@@ -95,7 +95,7 @@ spec:
     labels:
       peer.group: peer-broker
     size: 1
-    persistenceEnabled: true
+    persistenceEnabled: false
     clustered: false
     extraVolumes:
     - name: extra-volume


### PR DESCRIPTION
this prevents the operator from mounting a rw volume leaving the extra-volume to do the work of persisting messages for the broker.